### PR TITLE
Keep set contributors in sync with selected pieces

### DIFF
--- a/app/Controllers/Http/ParticipationImagesController.ts
+++ b/app/Controllers/Http/ParticipationImagesController.ts
@@ -10,6 +10,8 @@ import NotAuthenticated from 'App/Exceptions/NotAuthenticated'
 import NotAuthorized from 'App/Exceptions/NotAuthorized'
 import BadRequest from 'App/Exceptions/BadRequest'
 import Image from 'App/Models/Image'
+import InvalidInput from 'App/Exceptions/InvalidInput'
+import { selectedImageIds } from 'App/Helpers/coCreatorAttribution'
 
 export default class ParticipationImagesController extends BaseController {
   public async store({ request, session }: HttpContextContract) {
@@ -85,6 +87,15 @@ export default class ParticipationImagesController extends BaseController {
       throw new NotAuthorized(
         'Only the set creator, the contributor, or an admin can delete participation images',
       )
+    }
+
+    await participationImage.setSubmission.load('dynamicSetImages')
+    const isSelected = selectedImageIds(participationImage.setSubmission).some(
+      (imageId) => imageId.toString() === participationImage.imageId.toString(),
+    )
+
+    if (isSelected) {
+      throw new InvalidInput('Remove this piece from the set before deleting its contribution')
     }
 
     participationImage.deletedAt = DateTime.now()

--- a/app/Controllers/Http/SetSubmissionsController.ts
+++ b/app/Controllers/Http/SetSubmissionsController.ts
@@ -14,6 +14,7 @@ import InvalidInput from 'App/Exceptions/InvalidInput'
 import DynamicSetImages from 'App/Models/DynamicSetImages'
 import TimelineUpdate from 'App/Models/TimelineUpdate'
 import ParticipationImage from 'App/Models/ParticipationImage'
+import { hasDuplicateImageSelection } from 'App/Helpers/imageSelection'
 
 const PRINT_IMAGE_COLUMNS = [
   'edition_1ImageId',
@@ -23,6 +24,8 @@ const PRINT_IMAGE_COLUMNS = [
   'edition_20ImageId',
   'edition_40ImageId',
 ] as const
+
+const DYNAMIC_EDITIONS = [1, 4, 5, 10, 20, 40] as const
 
 export default class SetSubmissionsController extends BaseController {
   public async list({ request, session }: HttpContextContract) {
@@ -256,6 +259,8 @@ export default class SetSubmissionsController extends BaseController {
       request.input('edition_20_image_id', null),
       request.input('edition_40_image_id', null),
     ])
+    this.assertUniqueImageSelection(imageUUIDs)
+
     const images = await Promise.all(imageUUIDs.map((uuid) => Image.findBy('uuid', uuid)))
 
     // Maintain cache
@@ -484,6 +489,7 @@ export default class SetSubmissionsController extends BaseController {
     await this.creatorOrAdmin({ creator: submission.creatorAccount, session })
 
     const body = request.body()
+    await this.validateUniqueImageSelection(submission, body)
     const participationImage = await this.validateParticipationSelection(submission, body)
 
     if (submission.editionType === 'PRINT') {
@@ -506,6 +512,96 @@ export default class SetSubmissionsController extends BaseController {
       .preload('edition40Image')
       .preload('dynamicSetImages')
       .firstOrFail()
+  }
+
+  private assertUniqueImageSelection(
+    imageIds: (bigint | number | string | null | undefined)[],
+  ) {
+    if (hasDuplicateImageSelection(imageIds)) {
+      throw new InvalidInput('The same image cannot be selected more than once')
+    }
+  }
+
+  private async validateUniqueImageSelection(submission: SetSubmission, body: any) {
+    if (submission.editionType === 'PRINT') {
+      const requestedUuids = PRINT_IMAGE_COLUMNS.flatMap((column) => {
+        const uuid = body[column]
+        return typeof uuid === 'string' && uuid.length > 0 ? [uuid] : []
+      })
+      const images = requestedUuids.length
+        ? await Image.query().whereIn('uuid', [...new Set(requestedUuids)])
+        : []
+      const uuidToId = new Map(images.map((image) => [image.uuid, image.id]))
+      const unknownUuid = requestedUuids.find((uuid) => !uuidToId.has(uuid))
+
+      if (unknownUuid) throw new InvalidInput(`Unknown image UUID: ${unknownUuid}`)
+
+      const finalImageIds = PRINT_IMAGE_COLUMNS.map((column) => {
+        const uuid = body[column]
+        return typeof uuid === 'string' && uuid.length > 0
+          ? uuidToId.get(uuid)
+          : submission[column]
+      })
+
+      this.assertUniqueImageSelection(finalImageIds)
+      return
+    }
+
+    if (body.images !== undefined && !Array.isArray(body.images)) {
+      throw new InvalidInput('Images must be an array')
+    }
+
+    const imageConfigs: { edition: number; index: number; uuid: string | null }[] =
+      body.images || []
+    const validSlots = new Set(
+      DYNAMIC_EDITIONS.flatMap((edition) =>
+        Array.from({ length: edition }, (_, index) => `${edition}:${index + 1}`),
+      ),
+    )
+
+    for (const config of imageConfigs) {
+      if (
+        !config ||
+        !Number.isInteger(config.edition) ||
+        !Number.isInteger(config.index) ||
+        !validSlots.has(`${config.edition}:${config.index}`) ||
+        (config.uuid !== null && (typeof config.uuid !== 'string' || config.uuid.length === 0))
+      ) {
+        throw new InvalidInput('Invalid dynamic image selection')
+      }
+    }
+
+    const requestedUuids = imageConfigs.flatMap(({ uuid }) =>
+      typeof uuid === 'string' && uuid.length > 0 ? [uuid] : [],
+    )
+    const images = requestedUuids.length
+      ? await Image.query().whereIn('uuid', [...new Set(requestedUuids)])
+      : []
+    const uuidToId = new Map(images.map((image) => [image.uuid, image.id]))
+    const unknownUuid = requestedUuids.find((uuid) => !uuidToId.has(uuid))
+
+    if (unknownUuid) throw new InvalidInput(`Unknown image UUID: ${unknownUuid}`)
+
+    const finalImageIds = new Map<string, bigint | null | undefined>()
+    finalImageIds.set('1:1', submission.edition_1ImageId)
+
+    for (const edition of DYNAMIC_EDITIONS.filter((edition) => edition !== 1)) {
+      for (let index = 1; index <= edition; index++) {
+        finalImageIds.set(
+          `${edition}:${index}`,
+          submission.dynamicSetImages?.[`image_${edition}_${index}_id`],
+        )
+      }
+    }
+
+    for (const { edition, index, uuid } of imageConfigs) {
+      finalImageIds.set(
+        `${edition}:${index}`,
+        typeof uuid === 'string' && uuid.length > 0 ? uuidToId.get(uuid) : null,
+      )
+    }
+
+    this.assertUniqueImageSelection([...finalImageIds.values()])
   }
 
   private async validateParticipationSelection(

--- a/app/Controllers/Http/SetSubmissionsController.ts
+++ b/app/Controllers/Http/SetSubmissionsController.ts
@@ -14,7 +14,7 @@ import InvalidInput from 'App/Exceptions/InvalidInput'
 import DynamicSetImages from 'App/Models/DynamicSetImages'
 import TimelineUpdate from 'App/Models/TimelineUpdate'
 import ParticipationImage from 'App/Models/ParticipationImage'
-import { hasDuplicateImageSelection } from 'App/Helpers/imageSelection'
+import { isImageSelectionUnique } from 'App/Helpers/imageSelection'
 import Database from '@ioc:Adonis/Lucid/Database'
 import type { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
 import {
@@ -541,7 +541,7 @@ export default class SetSubmissionsController extends BaseController {
   private assertUniqueImageSelection(
     imageIds: (bigint | number | string | null | undefined)[],
   ) {
-    if (hasDuplicateImageSelection(imageIds)) {
+    if (!isImageSelectionUnique(imageIds)) {
       throw new InvalidInput('The same image cannot be selected more than once')
     }
   }

--- a/app/Controllers/Http/SetSubmissionsController.ts
+++ b/app/Controllers/Http/SetSubmissionsController.ts
@@ -15,6 +15,12 @@ import DynamicSetImages from 'App/Models/DynamicSetImages'
 import TimelineUpdate from 'App/Models/TimelineUpdate'
 import ParticipationImage from 'App/Models/ParticipationImage'
 import { hasDuplicateImageSelection } from 'App/Helpers/imageSelection'
+import Database from '@ioc:Adonis/Lucid/Database'
+import type { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
+import {
+  reconcileManualCoCreators,
+  reconcileSelectedCoCreators,
+} from 'App/Helpers/coCreatorAttribution'
 
 const PRINT_IMAGE_COLUMNS = [
   'edition_1ImageId',
@@ -296,13 +302,6 @@ export default class SetSubmissionsController extends BaseController {
       .filter((address: string) => isAddress(address))
       .map((address: string) => address.toLowerCase())
 
-    await submission.related('coCreators').query().delete()
-
-    for (const address of coCreatorAddresses) {
-      const account = await Account.firstOrCreate({ address })
-      await submission.related('coCreators').create({ accountId: account.id })
-    }
-
     const maxContributionsInput = parseInt(
       request.input('max_contributions_per_contributor', null),
     )
@@ -322,12 +321,12 @@ export default class SetSubmissionsController extends BaseController {
       edition_10Name: request.input('edition_10_name'),
       edition_20Name: request.input('edition_20_name'),
       edition_40Name: request.input('edition_40_name'),
-      edition_1ImageId: images[0]?.id,
-      edition_4ImageId: images[1]?.id,
-      edition_5ImageId: images[2]?.id,
-      edition_10ImageId: images[3]?.id,
-      edition_20ImageId: images[4]?.id,
-      edition_40ImageId: images[5]?.id,
+      edition_1ImageId: images[0]?.id ?? null,
+      edition_4ImageId: images[1]?.id ?? null,
+      edition_5ImageId: images[2]?.id ?? null,
+      edition_10ImageId: images[3]?.id ?? null,
+      edition_20ImageId: images[4]?.id ?? null,
+      edition_40ImageId: images[5]?.id ?? null,
       openForParticipation: request.input('open_for_participation', false),
       maxContributionsPerContributor,
     }
@@ -339,6 +338,15 @@ export default class SetSubmissionsController extends BaseController {
     }
 
     await submission.merge(updateData).save()
+
+    if (submission.editionType !== 'PRINT' && submission.dynamicSetImages) {
+      submission.dynamicSetImages.image_1_1_id = submission.edition_1ImageId
+      await submission.dynamicSetImages.save()
+      await submission.updateDynamicSetImagesCache()
+    }
+
+    await reconcileManualCoCreators(submission, coCreatorAddresses)
+    await reconcileSelectedCoCreators(submission)
     await submission.updateSearchString()
 
     return this.show(ctx)
@@ -488,18 +496,33 @@ export default class SetSubmissionsController extends BaseController {
 
     await this.creatorOrAdmin({ creator: submission.creatorAccount, session })
 
-    const body = request.body()
-    await this.validateUniqueImageSelection(submission, body)
-    const participationImage = await this.validateParticipationSelection(submission, body)
-
-    if (submission.editionType === 'PRINT') {
-      await this.updatePrintImages(submission, body)
-    } else {
-      await this.updateDynamicImages(submission, body)
+    if (submission.publishedAt) {
+      throw new InvalidInput(`Can't edit published set`)
     }
 
-    if (participationImage) {
-      await this.addParticipationCreator(submission, participationImage)
+    const body = request.body()
+    await this.validateUniqueImageSelection(submission, body)
+    await this.validateParticipationSelection(submission, body)
+
+    await Database.transaction(async (trx) => {
+      submission.useTransaction(trx)
+      submission.dynamicSetImages?.useTransaction(trx)
+
+      if (submission.editionType === 'PRINT') {
+        await this.updatePrintImages(submission, body, trx)
+      } else {
+        await this.updateDynamicImages(submission, body, trx)
+      }
+
+      await reconcileSelectedCoCreators(submission, trx)
+    })
+
+    if (submission.editionType !== 'PRINT') {
+      const committedSubmission = await SetSubmission.query()
+        .where('id', submission.id)
+        .preload('dynamicSetImages')
+        .firstOrFail()
+      await committedSubmission.updateDynamicSetImagesCache()
     }
 
     return SetSubmission.query()
@@ -511,6 +534,7 @@ export default class SetSubmissionsController extends BaseController {
       .preload('edition20Image')
       .preload('edition40Image')
       .preload('dynamicSetImages')
+      .preload('coCreators', (query) => query.preload('account'))
       .firstOrFail()
   }
 
@@ -537,10 +561,12 @@ export default class SetSubmissionsController extends BaseController {
       if (unknownUuid) throw new InvalidInput(`Unknown image UUID: ${unknownUuid}`)
 
       const finalImageIds = PRINT_IMAGE_COLUMNS.map((column) => {
+        if (!Object.prototype.hasOwnProperty.call(body, column)) return submission[column]
+
         const uuid = body[column]
-        return typeof uuid === 'string' && uuid.length > 0
-          ? uuidToId.get(uuid)
-          : submission[column]
+        if (uuid === null) return null
+
+        return typeof uuid === 'string' && uuid.length > 0 ? uuidToId.get(uuid) : null
       })
 
       this.assertUniqueImageSelection(finalImageIds)
@@ -647,79 +673,85 @@ export default class SetSubmissionsController extends BaseController {
     return participationImage
   }
 
-  private async addParticipationCreator(
+  private async updatePrintImages(
     submission: SetSubmission,
-    participationImage: ParticipationImage,
+    body: any,
+    client?: TransactionClientContract,
   ) {
-    const creatorAddress = participationImage.creatorAddress.toLowerCase()
-    if (creatorAddress === submission.creator.toLowerCase()) return
-
-    const account = await Account.firstOrCreate({ address: creatorAddress })
-    const existingCoCreator = await submission
-      .related('coCreators')
-      .query()
-      .where('accountId', account.id)
-      .first()
-
-    if (!existingCoCreator) {
-      await submission.related('coCreators').create({ accountId: account.id })
-    }
-  }
-
-  private async updatePrintImages(submission: SetSubmission, body: any) {
-    const uuids = PRINT_IMAGE_COLUMNS.filter((col) => body[col]).map((col) => body[col])
-    const images = await Image.query().whereIn('uuid', uuids)
+    const changedColumns = PRINT_IMAGE_COLUMNS.filter((column) =>
+      Object.prototype.hasOwnProperty.call(body, column),
+    )
+    const uuids = changedColumns.flatMap((column) =>
+      typeof body[column] === 'string' && body[column].length > 0 ? [body[column]] : [],
+    )
+    const images = uuids.length
+      ? await Image.query(client ? { client } : undefined).whereIn('uuid', uuids)
+      : []
     const uuidToId = new Map(images.map((img) => [img.uuid, img.id]))
 
     const updateData = Object.fromEntries(
-      PRINT_IMAGE_COLUMNS.flatMap((col) => {
+      changedColumns.map((col) => {
         const uuid = body[col]
-        if (!uuid) return []
+        if (uuid === null) return [col, null]
         const id = uuidToId.get(uuid)
         if (!id) throw new InvalidInput(`Unknown image UUID: ${uuid}`)
-        return [[col, id]]
+        return [col, id]
       }),
     )
 
     await submission.merge(updateData).save()
 
     if (submission.editionType === 'PRINT') {
-      await Image.query()
-        .where('setSubmissionId', submission.id)
-        .whereNotIn('uuid', uuids)
-        .update({ setSubmissionId: null })
-
-      await Promise.all(
-        images.map(async (image) => {
-          image.setSubmissionId = submission.id
-          await image.save()
-        }),
+      const selectedIds = PRINT_IMAGE_COLUMNS.map((column) => submission[column]).filter(
+        Boolean,
       )
+      const staleImages = Image.query(client ? { client } : undefined).where(
+        'setSubmissionId',
+        submission.id,
+      )
+
+      if (selectedIds.length) (staleImages as any).whereNotIn('id', selectedIds)
+      await staleImages.update({ setSubmissionId: null })
+
+      await (Image.query(client ? { client } : undefined) as any)
+        .whereIn('id', selectedIds)
+        .update({ setSubmissionId: submission.id })
     }
   }
 
-  private async updateDynamicImages(submission: SetSubmission, body: any) {
+  private async updateDynamicImages(
+    submission: SetSubmission,
+    body: any,
+    client?: TransactionClientContract,
+  ) {
     const imageConfigs: { edition: number; index: number; uuid: string | null }[] =
       body.images || []
 
     if (!submission.dynamicSetImages) {
-      const dynamicSetImages = await DynamicSetImages.create({})
+      const dynamicSetImages = await DynamicSetImages.create(
+        {},
+        client ? { client } : undefined,
+      )
       submission.dynamicSetImagesId = dynamicSetImages.id
+      submission.$setRelated('dynamicSetImages', dynamicSetImages)
       await submission.save()
-      await submission.load('dynamicSetImages')
     }
 
     const validUuids = imageConfigs
       .filter((c) => c.uuid !== null && c.uuid !== undefined)
       .map((c) => c.uuid as string)
 
-    const images = validUuids.length > 0 ? await Image.query().whereIn('uuid', validUuids) : []
+    const images =
+      validUuids.length > 0
+        ? await Image.query(client ? { client } : undefined).whereIn('uuid', validUuids)
+        : []
     const uuidToId = new Map(images.map((img) => [img.uuid, img.id]))
 
     for (const { edition, index, uuid } of imageConfigs) {
       // handle deletion case (when uuid is null)
       if (uuid === null || uuid === undefined) {
         submission.dynamicSetImages[`image_${edition}_${index}_id`] = null
+        if (edition === 1) submission.edition_1ImageId = null as any
         continue
       }
 
@@ -730,6 +762,7 @@ export default class SetSubmissionsController extends BaseController {
         submission.edition_1ImageId = imageId
 
         const img = images.find((img) => img.uuid === uuid)!
+        if (client) img.useTransaction(client)
         img.setSubmissionId = submission.id
         await img.save()
       }
@@ -739,7 +772,6 @@ export default class SetSubmissionsController extends BaseController {
 
     await submission.save()
     await submission.dynamicSetImages.save()
-    await submission.updateDynamicSetImagesCache()
   }
 
   protected async creatorOrAdmin({ creator, session }) {

--- a/app/Controllers/Http/SetSubmissionsController.ts
+++ b/app/Controllers/Http/SetSubmissionsController.ts
@@ -496,7 +496,7 @@ export default class SetSubmissionsController extends BaseController {
 
     await this.creatorOrAdmin({ creator: submission.creatorAccount, session })
 
-    if (submission.publishedAt) {
+    if (submission.publishedAt && !isAdmin(session)) {
       throw new InvalidInput(`Can't edit published set`)
     }
 

--- a/app/Helpers/coCreatorAttribution.ts
+++ b/app/Helpers/coCreatorAttribution.ts
@@ -1,0 +1,157 @@
+import Account from 'App/Models/Account'
+import CoCreator from 'App/Models/CoCreator'
+import ParticipationImage from 'App/Models/ParticipationImage'
+import SetSubmission from 'App/Models/SetSubmission'
+import type { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
+
+const EDITIONS = [1, 4, 5, 10, 20, 40] as const
+
+type ImageId = bigint | number | string
+type DatabaseClient = TransactionClientContract
+
+const normalizeImageId = (id: ImageId) => id.toString()
+
+export const selectedImageIds = (submission: SetSubmission): ImageId[] => {
+  const selected = new Map<string, ImageId>()
+  const add = (id: ImageId | null | undefined) => {
+    if (id !== null && id !== undefined) selected.set(normalizeImageId(id), id)
+  }
+
+  add(submission.edition_1ImageId)
+
+  if (submission.editionType === 'PRINT') {
+    add(submission.edition_4ImageId)
+    add(submission.edition_5ImageId)
+    add(submission.edition_10ImageId)
+    add(submission.edition_20ImageId)
+    add(submission.edition_40ImageId)
+  } else if (submission.dynamicSetImages) {
+    for (const edition of EDITIONS.filter((edition) => edition !== 1)) {
+      for (let index = 1; index <= edition; index++) {
+        add(submission.dynamicSetImages[`image_${edition}_${index}_id`])
+      }
+    }
+  }
+
+  return [...selected.values()]
+}
+
+export const selectedContributorAddresses = (
+  creatorAddress: string,
+  imageIds: ImageId[],
+  participations: Pick<ParticipationImage, 'imageId' | 'creatorAddress'>[],
+) => {
+  const selectedIds = new Set(imageIds.map(normalizeImageId))
+  const originalCreator = creatorAddress.toLowerCase()
+
+  return [
+    ...new Set(
+      participations
+        .filter((participation) => selectedIds.has(normalizeImageId(participation.imageId)))
+        .map((participation) => participation.creatorAddress.toLowerCase())
+        .filter((address) => address !== originalCreator),
+    ),
+  ]
+}
+
+const coCreatorQuery = (submission: SetSubmission, client?: DatabaseClient) =>
+  CoCreator.query(client ? { client } : undefined).where('setSubmissionId', submission.id)
+
+export const hasCoCreatorAttribution = (isManual: boolean, isSelectedContributor: boolean) =>
+  isManual || isSelectedContributor
+
+const saveOrDeleteCoCreator = async (coCreator: CoCreator, client?: DatabaseClient) => {
+  if (client) coCreator.useTransaction(client)
+
+  if (hasCoCreatorAttribution(coCreator.isManual, coCreator.isSelectedContributor)) {
+    await coCreator.save()
+  } else {
+    await coCreator.delete()
+  }
+}
+
+export const reconcileManualCoCreators = async (
+  submission: SetSubmission,
+  requestedAddresses: string[],
+  client?: DatabaseClient,
+) => {
+  const creatorAddress = submission.creator.toLowerCase()
+  const addresses = [
+    ...new Set(
+      requestedAddresses
+        .map((address) => address.toLowerCase())
+        .filter((address) => address !== creatorAddress),
+    ),
+  ]
+  const accounts = await Promise.all(
+    addresses.map((address) =>
+      Account.firstOrCreate({ address }, undefined, client ? { client } : undefined),
+    ),
+  )
+  const manualAccountIds = new Set(accounts.map((account) => account.id.toString()))
+  const existing = await coCreatorQuery(submission, client)
+  const existingAccountIds = new Set(
+    existing.map((coCreator) => coCreator.accountId.toString()),
+  )
+
+  for (const coCreator of existing) {
+    coCreator.isManual = manualAccountIds.has(coCreator.accountId.toString())
+    await saveOrDeleteCoCreator(coCreator, client)
+  }
+
+  for (const account of accounts) {
+    if (existingAccountIds.has(account.id.toString())) continue
+
+    await CoCreator.create(
+      {
+        setSubmissionId: submission.id,
+        accountId: account.id,
+        isManual: true,
+        isSelectedContributor: false,
+      },
+      client ? { client } : undefined,
+    )
+  }
+}
+
+export const reconcileSelectedCoCreators = async (
+  submission: SetSubmission,
+  client?: DatabaseClient,
+) => {
+  const imageIds = selectedImageIds(submission)
+  const participations = imageIds.length
+    ? await (ParticipationImage.query(client ? { client } : undefined) as any)
+        .where('setSubmissionId', submission.id)
+        .whereIn('imageId', imageIds)
+    : []
+  const addresses = selectedContributorAddresses(submission.creator, imageIds, participations)
+  const accounts = await Promise.all(
+    addresses.map((address) =>
+      Account.firstOrCreate({ address }, undefined, client ? { client } : undefined),
+    ),
+  )
+  const selectedAccountIds = new Set(accounts.map((account) => account.id.toString()))
+  const existing = await coCreatorQuery(submission, client)
+  const existingAccountIds = new Set(
+    existing.map((coCreator) => coCreator.accountId.toString()),
+  )
+
+  for (const coCreator of existing) {
+    coCreator.isSelectedContributor = selectedAccountIds.has(coCreator.accountId.toString())
+    await saveOrDeleteCoCreator(coCreator, client)
+  }
+
+  for (const account of accounts) {
+    if (existingAccountIds.has(account.id.toString())) continue
+
+    await CoCreator.create(
+      {
+        setSubmissionId: submission.id,
+        accountId: account.id,
+        isManual: false,
+        isSelectedContributor: true,
+      },
+      client ? { client } : undefined,
+    )
+  }
+}

--- a/app/Helpers/imageSelection.ts
+++ b/app/Helpers/imageSelection.ts
@@ -1,0 +1,16 @@
+export function hasDuplicateImageSelection(
+  imageIds: (bigint | number | string | null | undefined)[],
+) {
+  const seen = new Set<string>()
+
+  for (const imageId of imageIds) {
+    if (imageId === null || imageId === undefined) continue
+
+    const normalizedId = String(imageId)
+    if (seen.has(normalizedId)) return true
+
+    seen.add(normalizedId)
+  }
+
+  return false
+}

--- a/app/Helpers/imageSelection.ts
+++ b/app/Helpers/imageSelection.ts
@@ -1,16 +1,9 @@
-export function hasDuplicateImageSelection(
+export function isImageSelectionUnique(
   imageIds: (bigint | number | string | null | undefined)[],
 ) {
-  const seen = new Set<string>()
+  const selectedImageIds = imageIds
+    .filter((imageId) => imageId !== null && imageId !== undefined)
+    .map(String)
 
-  for (const imageId of imageIds) {
-    if (imageId === null || imageId === undefined) continue
-
-    const normalizedId = String(imageId)
-    if (seen.has(normalizedId)) return true
-
-    seen.add(normalizedId)
-  }
-
-  return false
+  return new Set(selectedImageIds).size === selectedImageIds.length
 }

--- a/app/Models/CoCreator.ts
+++ b/app/Models/CoCreator.ts
@@ -12,6 +12,12 @@ export default class CoCreator extends BaseModel {
   @column()
   public accountId: number
 
+  @column()
+  public isManual: boolean
+
+  @column()
+  public isSelectedContributor: boolean
+
   @belongsTo(() => SetSubmission, {
     foreignKey: 'setSubmissionId',
   })

--- a/database/migrations/1785600000000_track_co_creator_sources.ts
+++ b/database/migrations/1785600000000_track_co_creator_sources.ts
@@ -1,0 +1,32 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'co_creators'
+
+  public async up() {
+    await this.schema.alterTable(this.tableName, (table) => {
+      table.boolean('is_manual').notNullable().defaultTo(true)
+      table.boolean('is_selected_contributor').notNullable().defaultTo(false)
+    })
+
+    await this.db.rawQuery(`
+      DELETE FROM co_creators duplicate
+      USING co_creators original
+      WHERE duplicate.id > original.id
+        AND duplicate.set_submission_id = original.set_submission_id
+        AND duplicate.account_id = original.account_id
+    `)
+
+    await this.schema.alterTable(this.tableName, (table) => {
+      table.unique(['set_submission_id', 'account_id'])
+    })
+  }
+
+  public async down() {
+    await this.schema.alterTable(this.tableName, (table) => {
+      table.dropUnique(['set_submission_id', 'account_id'])
+      table.dropColumn('is_manual')
+      table.dropColumn('is_selected_contributor')
+    })
+  }
+}

--- a/database/migrations/1785600000000_track_co_creator_sources.ts
+++ b/database/migrations/1785600000000_track_co_creator_sources.ts
@@ -4,10 +4,19 @@ export default class extends BaseSchema {
   protected tableName = 'co_creators'
 
   public async up() {
-    await this.schema.alterTable(this.tableName, (table) => {
-      table.boolean('is_manual').notNullable().defaultTo(true)
-      table.boolean('is_selected_contributor').notNullable().defaultTo(false)
-    })
+    if (!(await this.schema.hasColumn(this.tableName, 'is_manual'))) {
+      await this.db.rawQuery(`
+        ALTER TABLE co_creators
+        ADD COLUMN is_manual boolean NOT NULL DEFAULT true
+      `)
+    }
+
+    if (!(await this.schema.hasColumn(this.tableName, 'is_selected_contributor'))) {
+      await this.db.rawQuery(`
+        ALTER TABLE co_creators
+        ADD COLUMN is_selected_contributor boolean NOT NULL DEFAULT false
+      `)
+    }
 
     await this.db.rawQuery(`
       DELETE FROM co_creators duplicate
@@ -17,16 +26,23 @@ export default class extends BaseSchema {
         AND duplicate.account_id = original.account_id
     `)
 
-    await this.schema.alterTable(this.tableName, (table) => {
-      table.unique(['set_submission_id', 'account_id'])
-    })
+    await this.db.rawQuery(`
+      CREATE UNIQUE INDEX IF NOT EXISTS co_creators_submission_account_unique
+      ON co_creators (set_submission_id, account_id)
+    `)
   }
 
   public async down() {
-    await this.schema.alterTable(this.tableName, (table) => {
-      table.dropUnique(['set_submission_id', 'account_id'])
-      table.dropColumn('is_manual')
-      table.dropColumn('is_selected_contributor')
-    })
+    await this.db.rawQuery(`
+      DROP INDEX IF EXISTS co_creators_submission_account_unique
+    `)
+
+    if (await this.schema.hasColumn(this.tableName, 'is_manual')) {
+      await this.db.rawQuery(`ALTER TABLE co_creators DROP COLUMN is_manual`)
+    }
+
+    if (await this.schema.hasColumn(this.tableName, 'is_selected_contributor')) {
+      await this.db.rawQuery(`ALTER TABLE co_creators DROP COLUMN is_selected_contributor`)
+    }
   }
 }

--- a/tests/functional/co_creator_attribution.spec.ts
+++ b/tests/functional/co_creator_attribution.spec.ts
@@ -1,0 +1,75 @@
+import { test } from '@japa/runner'
+import {
+  hasCoCreatorAttribution,
+  selectedContributorAddresses,
+  selectedImageIds,
+} from 'App/Helpers/coCreatorAttribution'
+import ParticipationImage from 'App/Models/ParticipationImage'
+import SetSubmission from 'App/Models/SetSubmission'
+
+const contributorA = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const contributorB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+const creator = '0xcccccccccccccccccccccccccccccccccccccccc'
+
+test('keeps a contributor attributed until their last selected piece is removed', ({
+  assert,
+}) => {
+  const participations = [
+    { imageId: 1n, creatorAddress: contributorA },
+    { imageId: 2n, creatorAddress: contributorA },
+    { imageId: 3n, creatorAddress: contributorB },
+  ] as ParticipationImage[]
+
+  assert.deepEqual(selectedContributorAddresses(creator, [1n, 2n, 3n], participations), [
+    contributorA,
+    contributorB,
+  ])
+  assert.deepEqual(selectedContributorAddresses(creator, [2n, 3n], participations), [
+    contributorA,
+    contributorB,
+  ])
+  assert.deepEqual(selectedContributorAddresses(creator, [3n], participations), [contributorB])
+})
+
+test('keeps manual credit after automatic contribution credit is removed', ({ assert }) => {
+  assert.isTrue(hasCoCreatorAttribution(true, true))
+  assert.isTrue(hasCoCreatorAttribution(true, false))
+  assert.isTrue(hasCoCreatorAttribution(false, true))
+  assert.isFalse(hasCoCreatorAttribution(false, false))
+})
+
+test('deduplicates participation records and excludes the original creator', ({ assert }) => {
+  const participations = [
+    { imageId: 1n, creatorAddress: contributorA },
+    { imageId: 1n, creatorAddress: contributorA.toUpperCase() },
+    { imageId: 2n, creatorAddress: creator },
+  ] as ParticipationImage[]
+
+  assert.deepEqual(selectedContributorAddresses(creator, [1n, 2n], participations), [
+    contributorA,
+  ])
+})
+
+test('reads the final selected image ids from print and dynamic submissions', ({ assert }) => {
+  const printSubmission = {
+    editionType: 'PRINT',
+    edition_1ImageId: 1n,
+    edition_4ImageId: 4n,
+    edition_5ImageId: null,
+    edition_10ImageId: 10n,
+    edition_20ImageId: null,
+    edition_40ImageId: 40n,
+  } as unknown as SetSubmission
+  const dynamicSubmission = {
+    editionType: 'DYNAMIC',
+    edition_1ImageId: 1n,
+    dynamicSetImages: {
+      image_1_1_id: 999n,
+      image_4_1_id: 4n,
+      image_4_2_id: 5n,
+    },
+  } as unknown as SetSubmission
+
+  assert.deepEqual(selectedImageIds(printSubmission), [1n, 4n, 10n, 40n])
+  assert.deepEqual(selectedImageIds(dynamicSubmission), [1n, 4n, 5n])
+})

--- a/tests/functional/image_selection.spec.ts
+++ b/tests/functional/image_selection.spec.ts
@@ -1,0 +1,12 @@
+import { test } from '@japa/runner'
+import { hasDuplicateImageSelection } from 'App/Helpers/imageSelection'
+
+test('detects duplicate image selections across slots', ({ assert }) => {
+  assert.isTrue(hasDuplicateImageSelection([1n, 2n, 1n]))
+  assert.isTrue(hasDuplicateImageSelection(['12', 12n]))
+})
+
+test('allows distinct and empty image selections', ({ assert }) => {
+  assert.isFalse(hasDuplicateImageSelection([1n, 2n, null, undefined, 3n]))
+  assert.isFalse(hasDuplicateImageSelection([null, null, undefined]))
+})

--- a/tests/functional/image_selection.spec.ts
+++ b/tests/functional/image_selection.spec.ts
@@ -1,12 +1,12 @@
 import { test } from '@japa/runner'
-import { hasDuplicateImageSelection } from 'App/Helpers/imageSelection'
+import { isImageSelectionUnique } from 'App/Helpers/imageSelection'
 
-test('detects duplicate image selections across slots', ({ assert }) => {
-  assert.isTrue(hasDuplicateImageSelection([1n, 2n, 1n]))
-  assert.isTrue(hasDuplicateImageSelection(['12', 12n]))
+test('rejects repeated image selections across slots', ({ assert }) => {
+  assert.isFalse(isImageSelectionUnique([1n, 2n, 1n]))
+  assert.isFalse(isImageSelectionUnique(['12', 12n]))
 })
 
-test('allows distinct and empty image selections', ({ assert }) => {
-  assert.isFalse(hasDuplicateImageSelection([1n, 2n, null, undefined, 3n]))
-  assert.isFalse(hasDuplicateImageSelection([null, null, undefined]))
+test('accepts distinct and empty image selections', ({ assert }) => {
+  assert.isTrue(isImageSelectionUnique([1n, 2n, null, undefined, 3n]))
+  assert.isTrue(isImageSelectionUnique([null, null, undefined]))
 })


### PR DESCRIPTION
## Summary

- prevent the same image from being selected in multiple print or dynamic edition slots
- track manual co-creators separately from contributors credited by selected pieces
- remove automatic contributor credit only after their final selected piece is removed
- prevent deleting a contribution while it is selected by the set

## Database migration

The single migration adds source flags to `co_creators`, removes duplicate submission/account rows, and creates a unique index for that pair. It is safe to retry after a partial run.

Existing co-creators are conservatively retained as manual credits so the migration does not remove existing attribution.

**Deployment requirement:** run `node ace migration:run --force` before switching the new API process into service, because the new API writes the added columns.

## Verification

- `npx --yes node@20 ace build --production`
- `npx --yes node@20 ace test functional --files tests/functional/co_creator_attribution.spec.ts --files tests/functional/image_selection.spec.ts` — 6 passed
- rehearsed all 122 migrations on a disposable PostgreSQL database
- verified duplicate cleanup, unique-index enforcement, partial-run retry, and rollback
